### PR TITLE
Format multi-word currency unit as on website

### DIFF
--- a/Stately/app/src/main/java/com/lloydtorres/stately/helpers/SparkleHelper.java
+++ b/Stately/app/src/main/java/com/lloydtorres/stately/helpers/SparkleHelper.java
@@ -440,6 +440,19 @@ public class SparkleHelper {
             return String.format(c.getString(R.string.val_currency), getPrettifiedNumber(d), suffix);
         }
     }
+    
+    /**
+     * Takes in a currency name from the NationStates API and formats it to the
+     * NS format.
+     * @param currency The currency unit.
+     * @return A nicely-formatted currency-string in NS format.
+     */
+    public static String getCurrencyFormatted(String currency)
+    {
+        String[] words = currency.split(" ");
+        words[0] = English.plural(words[0]);
+        return Joiner.on(" ").join(words);
+    }
 
     /**
      * Takes in a money value and currency name from the NationStates API and formats it to the
@@ -456,7 +469,7 @@ public class SparkleHelper {
         if (money < 1000000L)
         {
             // If the money is less than 1 million, we don't need a suffix.
-            return String.format(c.getString(R.string.val_currency), getPrettifiedNumber(money), English.plural(currency));
+            return String.format(c.getString(R.string.val_currency), getPrettifiedNumber(money), getCurrencyFormatted(currency));
         }
         else
         {
@@ -479,7 +492,7 @@ public class SparkleHelper {
                 money /= 1000000000000L;
             }
 
-            return String.format(c.getString(R.string.val_suffix_currency), getPrettifiedNumber(money), suffix, English.plural(currency));
+            return String.format(c.getString(R.string.val_suffix_currency), getPrettifiedNumber(money), suffix, getCurrencyFormatted(currency));
         }
 
     }
@@ -997,7 +1010,7 @@ public class SparkleHelper {
             target = target.replace("@@TYPE@@", nationData.prename);
             target = target.replace("@@ANIMAL@@", nationData.animal);
             target = target.replace("@@CURRENCY@@", nationData.currency);
-            target = target.replace("@@PL(CURRENCY)@@", English.plural(nationData.currency));
+            target = target.replace("@@PL(CURRENCY)@@", getCurrencyFormatted(nationData.currency));
             target = target.replace("@@SLOGAN@@", nationData.motto);
             target = target.replace("@@DEMONYM@@", nationData.demAdjective);
             target = target.replace("@@DEMONYM2@@", nationData.demNoun);

--- a/Stately/app/src/main/java/com/lloydtorres/stately/helpers/SparkleHelper.java
+++ b/Stately/app/src/main/java/com/lloydtorres/stately/helpers/SparkleHelper.java
@@ -441,6 +441,8 @@ public class SparkleHelper {
         }
     }
     
+    public static final Pattern CURRENCY_PLURALIZE = Pattern.compile("^(.+?)( +of .+)?$");
+    
     /**
      * Takes in a currency name from the NationStates API and formats it to the
      * NS format.
@@ -449,9 +451,12 @@ public class SparkleHelper {
      */
     public static String getCurrencyFormatted(String currency)
     {
-        String[] words = currency.split(" ");
-        words[0] = English.plural(words[0]);
-        return Joiner.on(" ").join(words);
+        Matcher m = CURRENCY_PLURALIZE.matcher(currency);
+        m.matches();
+        String pluralize = m.group(1);
+        String suffix = m.group(2);
+        pluralize = English.plural(pluralize);
+        return Joiner.on("").skipNulls().join(pluralize, suffix);
     }
 
     /**


### PR DESCRIPTION
Title explains it all - I have noticed that on the website, if you have a currency unit like `bar of gold`, the plural will be `bars of gold`. In the app, it will show as `bar of golds`. This change is untested as I have no android build suite set up (I am no Android dev). I am sorry about that.

Edit: Love your app, by the way!