### PR TITLE
Removed Crashlytics and references to maven.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,6 @@ Stately uses the following open-source libraries:
 * [SwipyRefreshLayout](https://github.com/omadahealth/SwipyRefreshLayout)
 * [Volley](https://github.com/google/volley)
 
-Stately also uses the following proprietary libraries:
-
-* [Crashlytics](https://try.crashlytics.com/)
-
 ### Creative Commons
 
 Stately uses Creative Commons-licensed content from the following sources:

--- a/Stately/app/build.gradle
+++ b/Stately/app/build.gradle
@@ -1,14 +1,11 @@
 buildscript {
     repositories {
-        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
     }
 }
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 28
@@ -33,7 +30,6 @@ android {
 repositories {
     maven { url "https://jitpack.io" }
     jcenter()
-    maven { url 'https://maven.fabric.io/public' }
 }
 
 dependencies {
@@ -42,9 +38,6 @@ dependencies {
         exclude module: 'stax'
         exclude module: 'stax-api'
         exclude module: 'xpp3'
-    }
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
     }
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:design:28.0.0'

--- a/Stately/app/fabric.properties
+++ b/Stately/app/fabric.properties
@@ -1,3 +1,0 @@
-#Contains API Secret used to validate your application. Commit to internal source control; avoid making secret public.
-#Sat Jan 30 00:11:24 EST 2016
-apiSecret=d610ebd84f153e9c52b2e990c038433dd6f7a6be3209ea4c1c6d5b634ab35e57

--- a/Stately/app/src/main/AndroidManifest.xml
+++ b/Stately/app/src/main/AndroidManifest.xml
@@ -138,9 +138,6 @@
         <service android:name=".push.AlphysLollipopService"
             android:label="@string/stately_alphys"
             android:permission="android.permission.BIND_JOB_SERVICE"/>
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="651c62b07195273645b7c74e9b21a68bf3d124cd" />
     </application>
 
 </manifest>

--- a/Stately/app/src/main/java/com/lloydtorres/stately/core/StatelyApp.java
+++ b/Stately/app/src/main/java/com/lloydtorres/stately/core/StatelyApp.java
@@ -16,12 +16,10 @@
 
 package com.lloydtorres.stately.core;
 
-import com.crashlytics.android.Crashlytics;
 import com.lloydtorres.stately.push.TrixHelper;
 import com.lloydtorres.stately.settings.SettingsActivity;
 import com.orm.SugarApp;
 
-import io.fabric.sdk.android.Fabric;
 
 /**
  * Created by Lloyd on 2016-01-29.
@@ -32,11 +30,6 @@ public class StatelyApp extends SugarApp {
     @Override
     public void onCreate() {
         super.onCreate();
-
-        // analytics
-        if (SettingsActivity.getCrashReportSetting(this)) {
-            Fabric.with(this, new Crashlytics());
-        }
 
         // notification channels
         TrixHelper.initNotificationChannels(this);

--- a/Stately/app/src/main/java/com/lloydtorres/stately/settings/SettingsActivity.java
+++ b/Stately/app/src/main/java/com/lloydtorres/stately/settings/SettingsActivity.java
@@ -47,7 +47,6 @@ public class SettingsActivity extends SlidrActivity implements SharedPreferences
     public static final String SETTING_AUTOLOGIN = "setting_autologin";
     public static final String SETTING_ISSUECONFIRM = "setting_issueconfirm";
     public static final String SETTING_EXITCONFIRM = "setting_exitconfirm";
-    public static final String SETTING_CRASHREPORT = "setting_crashreport";
 
     public static final String SETTING_NOTIFS = "setting_notifs";
     public static final String SETTING_NOTIFS_CHECK = "setting_notifs_check";
@@ -139,12 +138,6 @@ public class SettingsActivity extends SlidrActivity implements SharedPreferences
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         switch (key) {
-            case SETTING_CRASHREPORT:
-                if (isFinishing()) {
-                    return;
-                }
-                dialogBuilder.setMessage(getString(R.string.warn_crashreport)).setPositiveButton(getString(R.string.got_it), null).show();
-                break;
             case SETTING_NOTIFS:
             case SETTING_NOTIFS_CHECK:
                 TrixHelper.stopAlarmForAlphys(this);
@@ -182,11 +175,6 @@ public class SettingsActivity extends SlidrActivity implements SharedPreferences
     public static boolean getConfirmExitSetting(Context c) {
         SharedPreferences storage = PreferenceManager.getDefaultSharedPreferences(c);
         return storage.getBoolean(SettingsActivity.SETTING_EXITCONFIRM, true);
-    }
-
-    public static boolean getCrashReportSetting(Context c) {
-        SharedPreferences storage = PreferenceManager.getDefaultSharedPreferences(c);
-        return storage.getBoolean(SettingsActivity.SETTING_CRASHREPORT, true);
     }
 
     /**

--- a/Stately/app/src/main/res/values/strings.xml
+++ b/Stately/app/src/main/res/values/strings.xml
@@ -529,8 +529,6 @@
     <string name="setting_title_behavior">General</string>
     <string name="setting_autologin">Log in automatically</string>
     <string name="setting_issueconfirm">Confirm issue decisions</string>
-    <string name="setting_crashreport">Send crash reports</string>
-    <string name="warn_crashreport">Stately must be restarted before changes take effect.</string>
     <string name="got_it">Got It</string>
     <string name="setting_title_notifs">Notifications</string>
     <string name="setting_notifs">Get notifications</string>

--- a/Stately/app/src/main/res/xml/settings.xml
+++ b/Stately/app/src/main/res/xml/settings.xml
@@ -20,11 +20,6 @@
             android:title="@string/setting_exitconfirm"
             android:defaultValue="true"
             android:icon="@null" />
-        <android.support.v7.preference.SwitchPreferenceCompat
-            android:key="setting_crashreport"
-            android:title="@string/setting_crashreport"
-            android:defaultValue="true"
-            android:icon="@null" />
     </android.support.v7.preference.PreferenceCategory>
 
     <android.support.v7.preference.PreferenceCategory


### PR DESCRIPTION
This PR removes Crashlytics and reference to maven.io. This means it is buildable by F-Droid. To be included, metadata has to be added, see #17 .