### PR TITLE
Added German translation for full and short desc as well as the title

### DIFF
--- a/Stately/fastlane/metadata/android/de-DE/full_description.txt
+++ b/Stately/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,0 +1,17 @@
+Stately ist eine unoffizielle App für NationStates (nationstates.net), ein textbasiertes Politiksimulationsspiel. Stately liefert die beste NationStates-Erfahrung auf deinem Mobilgerät.
+
+<b>Stately ermöglicht:</b>
+• Statistiken, Gesetze, Rankings und Events anzusehen.
+• Auf Probleme einer Nation zu antworten.
+• Einloggen und zwischen verschiedenen Nationen zu wechseln.
+• Verschiedene Regionen anzusehen und zwischen ihnen umziehen.
+• Mit anderen Spielern zu chatten.
+• Aktuelle World-Assembly-Abstimmungen zu beobachten und abzustimmen.
+• Andere Nationen zu empfehlen und am R/D Gameplay teilzunehmen.
+• Telegramme zu lesen, verwalten, schreiben und zu beantworten.
+• Durch Statistiken nationale, regionale und weltweite Trends abzulesen.
+• Schnellen Überblick durch den Aktivitätsverlauf zu erhalten.
+• Benachrichtigt zu werden bei Telegrammen, Problemen und anderen Events.
+• Anpassungsfähigkeit unter anderem durch fünf verschiedene Themes.
+
+Hinweis: die App selbst ist nicht auf Deutsch verfügbar.

--- a/Stately/fastlane/metadata/android/de-DE/short_description.txt
+++ b/Stately/fastlane/metadata/android/de-DE/short_description.txt
@@ -1,0 +1,1 @@
+Eine unoffizielle App für NationStates - eine Politiksimulation.

--- a/Stately/fastlane/metadata/android/de-DE/title.txt
+++ b/Stately/fastlane/metadata/android/de-DE/title.txt
@@ -1,0 +1,1 @@
+Stately für NationStates


### PR DESCRIPTION
It got a bit more verbose than I like it, but in German there's this added problem of a informal and a formal way of referring to the reader, which is why I have written it in a passive way/from the view of Stately.
Meaning:
"With Stately, you can"
Has been translated to:
"Stately makes it possible to"
This is the same way eg KDE solved their problems with that.

Another thing:
Does R/D mean research and development? It's probably well understood in the NationState community so I just left it as is.