### PR TITLE
add get it on f-droid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Stately
 
 **Stately** is an unofficial [NationStates](http://www.nationstates.net/) app for Android.
 
-Get Stately on: [Google Play](https://play.google.com/store/apps/details?id=com.lloydtorres.stately) | [Amazon Appstore](http://www.amazon.com/gp/product/B01E4R7T1C/ref=mas_pm_stately_for_nationstates)
+Get Stately on: [Google Play](https://play.google.com/store/apps/details?id=com.lloydtorres.stately) | [F-Droid](https://f-droid.org/packages/com.lloydtorres.stately) | [Amazon Appstore](http://www.amazon.com/gp/product/B01E4R7T1C/ref=mas_pm_stately_for_nationstates)
 
 ### Features
 


### PR DESCRIPTION
Adds the F-Droid repo link to the README.md.
One of the packagers [finally answered](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/7540#note_533974184), all that is missing is a new tag, since the fastlane changes are not covered by the most recent one. My recomendation would be:
1. retagging the latest release to the latest commit
2. I modify the metadata to point to that instead 
3. F-Droid merges the metadata
4. this patch here

Thank you for sticking with me through this journey :)