### PR TITLE
[fdroid] add warning for nationstates.net tracking

### DIFF
--- a/Stately/app/src/main/java/com/lloydtorres/stately/login/LoginActivity.java
+++ b/Stately/app/src/main/java/com/lloydtorres/stately/login/LoginActivity.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.net.Uri;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -401,12 +402,22 @@ public class LoginActivity extends BroadcastableActivity {
             }
         };
 
+        DialogInterface.OnClickListener openExternalDialogListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                Intent openLinkExternalIntent = new Intent(Intent.ACTION_VIEW);
+                openLinkExternalIntent.setData(Uri.parse(WebRegisterActivity.REGISTER_URL));
+                startActivity(openLinkExternalIntent);
+            }
+        };
+
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this,
                 RaraHelper.getThemeMaterialDialog(this));
         dialogBuilder.setTitle(R.string.create_nation)
                 .setMessage(R.string.create_nation_redirect)
                 .setPositiveButton(R.string.create_continue, dialogListener)
                 .setNegativeButton(R.string.explore_negative, null)
+                .setNeutralButton(R.string.open_in_browser, openExternalDialogListener)
                 .show();
     }
 

--- a/Stately/app/src/main/res/values/strings.xml
+++ b/Stately/app/src/main/res/values/strings.xml
@@ -20,7 +20,8 @@
     <string name="password">Password</string>
     <string name="log_in">Log In</string>
     <string name="create_nation">Create New Nation</string>
-    <string name="create_nation_redirect">To create a new nation, you\'ll be redirected to the NationStates website.</string>
+    <string name="create_nation_redirect">To create a new nation, a native WebView of the NationStates website will be opened. This website contains tracking scripts.\nIf you want to avoid this, consider creating a nation in a browser with tracking protection (for example through the \'uBlock Origin\' extension). Alternatively consider using a DNS server with tracking protection and/or ad-blocking.</string>
+    <string name="open_in_browser">Open in browser</string>
     <string name="create_continue">Continue</string>
     <string name="create_finish">Type in your nation name and password to get started.</string>
     <string name="create_error">Something went wrong with the create a new nation process. Please try again on the NationStates website (nationstates.net).</string>


### PR DESCRIPTION
Nationstates.net uses Google Analytics, this patch adds a warning when clicking "create new nation", and now offers to open it in a browser also. This is a result of a discussion with the f-droid maintainers/packagers.
Please be so kind to retag the version once this is merged.

Thanks for your ongoing support!